### PR TITLE
fix the bug about indexof function

### DIFF
--- a/js/lottery.js
+++ b/js/lottery.js
@@ -96,7 +96,9 @@
             query: function( val ) {
                 for(var key in window.localStorage){
                     if( 'first|second|third'.indexOf(key) >= 0 ){
-                        if(config.get( key ).indexOf(val) >= 0){
+                        //if(config.get( key ).indexOf(val) >= 0){
+						var currKeys = config.get( key ).split(",");
+						if($.inArray(val+'', currKeys) >= 0){
                             return true;
                         }
                     }
@@ -631,7 +633,9 @@
 
             for(var key2 in window.localStorage){
                 if( 'first|second|third'.indexOf(key2) >= 0 ){
-                    if(config.get( key2 ).indexOf(index) >= 0){
+                    //if(config.get( key2 ).indexOf(index) >= 0){
+					var currKeys = config.get( key2 ).split(",");
+					if($.inArray(index+'', currKeys) != "-1"){	
                         config.remove(key2, index);
                         break;
                     }


### PR DESCRIPTION
比如，如果key2是**15,20**的时候，0,1,2,5,15,20都会被排除在中奖名单之外。
因为indexof函数只是单纯判断字符串是否包含目标对象，没有进行值得比较。